### PR TITLE
Bump Scala 2.13 and SBT so it supports Java 21

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val myAwesomeFramework =
     .enablePlugins(SbtIdeaPlugin)
     .settings(
       version := "0.0.1-SNAPSHOT",
-      scalaVersion := "2.13.10",
+      scalaVersion := "2.13.15",
       ThisBuild / intellijPluginName := "My Awesome Framework",
       ThisBuild / intellijBuild      := "231.9011.34",
       ThisBuild / intellijPlatform   := IntelliJPlatform.IdeaCommunity,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.3
+sbt.version=1.10.2


### PR DESCRIPTION
This PR bumps Scala 2.13 and SBT to latest, so this template works with Java 21 too.


- [SBT v1.9.0](https://github.com/sbt/sbt/releases/tag/v1.9.0)+ supports Java 21
- [Scala 2.13.11](https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html)+ supports Java 21

